### PR TITLE
Fix AimpPlugin.AimpCore property which was never initialized.

### DIFF
--- a/aimp_dotnet/AIMPPlugin.h
+++ b/aimp_dotnet/AIMPPlugin.h
@@ -21,7 +21,7 @@ namespace AIMP
 			{
 				IAimpCore^ get()
 				{
-					return _aimpCore;
+					return Player->Core;
 				}
 			}
 
@@ -42,7 +42,6 @@ namespace AIMP
 			}
 
 		private:
-			IAimpCore^ _aimpCore;
 			ServiceMenuManager^ _menuManager;
 		};
 	}


### PR DESCRIPTION
Remove the _aimpCore field and use Player instead.